### PR TITLE
Issues/36-InefficientHashComparison

### DIFF
--- a/conwaylib/Game.cs
+++ b/conwaylib/Game.cs
@@ -10,7 +10,8 @@ namespace ConwayLib
   /// </summary>
   public sealed class Game
   {
-    private readonly HashSet<byte[]> mHistory = new HashSet<byte[]>();
+    private HashComparer mHashComparer;
+    private HashSet<byte[]> mHistory;
 
     private readonly IEvolution mEvolution;
     private IMutableBoard mCurBoard, mNextBoard;
@@ -21,6 +22,10 @@ namespace ConwayLib
     /// </summary>
     public Game(IReadableBoard initialBoard, IEvolution evolution)
     {
+      
+      mHashComparer = new HashComparer();
+      mHistory = new HashSet<byte[]>(mHashComparer);
+
       mCurBoard = initialBoard.MutableCopy();
       mNextBoard = new Board(initialBoard.Width, initialBoard.Height);
       

--- a/conwaylib/Game.cs
+++ b/conwaylib/Game.cs
@@ -21,8 +21,7 @@ namespace ConwayLib
     /// rules <paramref name="evolution"/>.
     /// </summary>
     public Game(IReadableBoard initialBoard, IEvolution evolution)
-    {
-      
+    {           
       mHashComparer = new HashComparer();
       mHistory = new HashSet<byte[]>(mHashComparer);
 
@@ -51,7 +50,7 @@ namespace ConwayLib
 
       (mNextBoard, mCurBoard) = (mCurBoard, mNextBoard);
       var hash = mCurBoard.GetUniqueHash();
-      previousExists = mHistory.Any(h => h.SequenceEqual(hash));
+      previousExists = mHistory.Contains(hash);
       mHistory.Add(hash);
       return mCurBoard;
     }

--- a/conwaylib/Game.cs
+++ b/conwaylib/Game.cs
@@ -10,7 +10,6 @@ namespace ConwayLib
   /// </summary>
   public sealed class Game
   {
-    private HashComparer mHashComparer;
     private HashSet<byte[]> mHistory;
 
     private readonly IEvolution mEvolution;
@@ -21,9 +20,8 @@ namespace ConwayLib
     /// rules <paramref name="evolution"/>.
     /// </summary>
     public Game(IReadableBoard initialBoard, IEvolution evolution)
-    {           
-      mHashComparer = new HashComparer();
-      mHistory = new HashSet<byte[]>(mHashComparer);
+    {
+      mHistory = new HashSet<byte[]>(new HashComparer());
 
       mCurBoard = initialBoard.MutableCopy();
       mNextBoard = new Board(initialBoard.Width, initialBoard.Height);

--- a/conwaylib/HashComparer.cs
+++ b/conwaylib/HashComparer.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConwayLib
+{
+    public class HashComparer : IEqualityComparer<byte[]>
+    {
+        public bool Equals(byte[] hash1, byte[] hash2)
+        {
+            if (hash1 == null && hash2 == null)
+                return true;
+            else if (hash1 == null || hash2 == null)
+                return false;
+            else
+                return hash1.SequenceEqual(hash2);
+        }
+
+        public int GetHashCode(byte[] bx)
+        {
+            int sum = 0;
+            bx.Select(x => sum+=x);
+            return sum;
+        }
+    }
+}

--- a/conwaylib/HashComparer.cs
+++ b/conwaylib/HashComparer.cs
@@ -16,11 +16,18 @@ namespace ConwayLib
                 return hash1.SequenceEqual(hash2);
         }
 
-        public int GetHashCode(byte[] bx)
+        public int GetHashCode(byte[] bytes)
         {
-            int sum = 0;
-            bx.Select(x => sum+=x);
-            return sum;
+            unchecked
+            {
+                // byte arrays do not support .Sum(), which is why I think I have to use a loop;
+                int sum = 0;
+                foreach (var b in bytes)
+                {
+                    sum+=b;
+                }
+                return sum;                
+            }
         }
     }
 }

--- a/conwaylib/HashComparer.cs
+++ b/conwaylib/HashComparer.cs
@@ -20,13 +20,7 @@ namespace ConwayLib
         {
             unchecked
             {
-                // byte arrays do not support .Sum(), which is why I think I have to use a loop;
-                int sum = 0;
-                foreach (var b in bytes)
-                {
-                    sum+=b;
-                }
-                return sum;                
+                return bytes.Sum(b => (int)b);                
             }
         }
     }

--- a/conwaylibtests/HashComparerTests.cs
+++ b/conwaylibtests/HashComparerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit;
+using NUnit.Framework;
+
+namespace ConwayLib.TestCase
+{
+    [TestFixture]
+    public sealed class HashComparerTests
+    {
+        [TestCase(new byte[] {0,1,2,3})]
+        [TestCase(new byte[] {255,128,45,32})]
+        public void HashSetOfByteArrays_ShouldSayItContainsArray_WhenItExists(byte[] myHash)
+        {
+            HashSet<byte[]> myHashSet = new HashSet<byte[]>(new HashComparer());
+            myHashSet.Add(myHash);
+
+            Assert.That(myHashSet.Contains(myHash), Is.True);
+        }        
+        
+        [TestCase(new byte[] {0,1,2,3})]
+        [TestCase(new byte[] {255,128,45,32})]
+        public void HashSetOfByteArrays_ShouldSayItDoesntContainArray_WhenItDoesntExists(byte[] myHash)
+        {
+            HashSet<byte[]> myHashSet = new HashSet<byte[]>(new HashComparer()) {new byte[] {0,1,0,0,0,1}};
+            
+            Assert.That(myHashSet.Contains(myHash), Is.False);
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I created a HashComparer object that implements the IEqualityComparer interface. This correctly performs comparisons of byte arrays, and allows us to use the faster `HashSet.Contains()` function instead of `HashSet.Any()` function to see if a previous board exists in the simulation's history.