### PR TITLE
ConnectionString now stored in UserSectrets

### DIFF
--- a/conwaywebapi/appsettings.json
+++ b/conwaywebapi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=DESKTOP-5ED6RRO\\SQLEXPRESS;Database=Conway;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "DefaultConnectionStringSecure"
   },
   "Logging": {
     "LogLevel": {

--- a/conwaywebapi/conwaywebapi.csproj
+++ b/conwaywebapi/conwaywebapi.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>ConwayWebApi</RootNamespace>
+    <UserSecretsId>d423002b-5a4c-43c4-924d-8331c827e837</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In this PR, I fixed the security issue by moving the connection string to my UserSecrets. In production, the connection string should be put in the appsettings.json.